### PR TITLE
allowing attribute names which are not valid comp identifiers

### DIFF
--- a/src/comp/grammar.y
+++ b/src/comp/grammar.y
@@ -211,6 +211,12 @@ postfix_expression:
 		$$ = $1.Field($3, pos)
 		gDecls.SetType($$, TypeOfField{$1.Id, $3})
 	}
+    | postfix_expression '[' STRING ']'
+	{
+		pos := gDecls.UseField($1.Id, $3)
+		$$ = $1.Field($3, pos)
+		gDecls.SetType($$, TypeOfField{$1.Id, $3})
+	}
     | postfix_expression '(' expression_list_or_empty ')'
 	{
 		eids := make([]int64, len($3))

--- a/src/comp/store.go
+++ b/src/comp/store.go
@@ -108,12 +108,7 @@ func readHead(fileName string) (ObjectType, error) {
 	fields := strings.Split(str, "\t")
 	res := make(ObjectType, len(fields))
 	for i, f := range fields {
-		f = strings.Trim(f, " \r\n")
-		if !IsIdent(f) {
-			return nil, fmt.Errorf("invalid field name: '%v'", f)
-		}
-
-		res[i].Name = f
+		res[i].Name = strings.Trim(f, " \r\n")
 		res[i].Type = ScalarType(0)
 	}
 

--- a/src/comp/web_test.go
+++ b/src/comp/web_test.go
@@ -125,7 +125,9 @@ func ExampleObjects() {
 	run(`{id: 1, name: "foo"}`)
 	run(`{id: 1, children: [2, 3]}`)
 	run(`{id: 1, name: "foo"}.id`)
+	run(`{id: 1, name: "foo"}["id"]`)
 	run(`{id: 1, name: "foo"}.name`)
+	run(`{id: 1, name: "foo"}["name"]`)
 	run(`{id: 1, children: [2,3]}.children`)
 	run(`{id: 1, obj: {parent: 1, value: "hello"}}.obj`)
 	run(`{id: 1, obj: {parent: 1, value: "hello"}}.obj.value`)
@@ -134,6 +136,8 @@ func ExampleObjects() {
 	// {"id":1,"name":"foo"}
 	// {"children":[2,3],"id":1}
 	// 1
+	// 1
+	// "foo"
 	// "foo"
 	// [2,3]
 	// {"parent":1,"value":"hello"}


### PR DESCRIPTION
There are a lot of datasets available with rather complex attributes names which are not valid comp identifiers. This change allows to access these attributes in the following fashion:

```
record["complex attribute name"]
```

example:

```
[ a["my identifiers with spaces"] | a <- inputdata ]
```

The attributes with names as valid comp identifiers are therefore accessible in two ways:

```
[ a.id | a <- inputdata ]
```

or

```
[ a["id"] | a <- inputdata ]
```
