### PR TITLE
supporting JSON input files

### DIFF
--- a/src/comp/store_test.go
+++ b/src/comp/store_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2013 Julius Chrobak. You can use this source code
+// under the terms of the MIT License found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func _traverse(t *testing.T, jsonBlob []byte) (Type, Value, error) {
+	var data interface{}
+	err := json.Unmarshal(jsonBlob, &data)
+	if err != nil {
+		t.Log("error:", err)
+		t.FailNow()
+	}
+	return traverse(nil, data)
+}
+
+func ok(t *testing.T, jsonBlob []byte) {
+	rt, rv, err := _traverse(t, jsonBlob)
+	if err != nil || rt == nil || rv == nil {
+		t.Log("error:", err)
+		t.FailNow()
+	}
+}
+
+func err(t *testing.T, jsonBlob []byte) {
+	rt, rv, err := _traverse(t, jsonBlob)
+	if err == nil || rt != nil || rv != nil {
+		t.Log("error:", err)
+		t.FailNow()
+	}
+}
+
+func TestJSONBasic(t *testing.T) {
+	ok(t, []byte(`
+        [1,2,3,4]
+    `))
+
+	ok(t, []byte(`
+        {"Name": "Platypus"}
+    `))
+
+	ok(t, []byte(`[
+        {"Name": "Platypus"}, {"Name": "Quoll"}
+    ]`))
+
+	ok(t, []byte(`[
+        {"Name": "Platypus"}, {"Name": 1}
+    ]`))
+
+	ok(t, []byte(`[
+        {"Name": "Platypus"}, {"Name": true}
+    ]`))
+
+	ok(t, []byte(`
+        [1,"hello"]
+    `))
+
+	err(t, []byte(`
+        [{},"hello"]
+    `))
+
+	err(t, []byte(`[
+        {"Name": "Platypus"}, {"Name": []}
+    ]`))
+
+	err(t, []byte(`[
+        {"Name": "Platypus"}, {"Name": {}}
+    ]`))
+
+	err(t, []byte(`[
+        {"Name": "Platypus"}, {"Id": "Quoll"}
+    ]`))
+
+	err(t, []byte(`[
+        {"Name": "Platypus"}, {"name": "Quoll"}
+    ]`))
+}
+
+func TestJSONNested(t *testing.T) {
+	ok(t, []byte(`
+        {"Order": [1,2,3,4]}
+    `))
+
+	ok(t, []byte(`
+        {"Order": [{"Id": 1}, {"Id": 2}, {"Id": 3}]}
+    `))
+
+	ok(t, []byte(` [
+        {"Order": [{"Id": 1}, {"Id": 2}, {"Id": 3}]},
+        {"Order": [{"Id": 1}]}
+    ]`))
+
+	ok(t, []byte(` [
+        {"Order": [{"Id": 1}, {"Id": 2}, {"Id": 3}]},
+        {"Order": [{"Id": "hello"}]}
+    ]`))
+
+	err(t, []byte(` [
+        {"Order": [{"Id": 1}, {"Id": 2}, {"Id": 3}]},
+        {"Order": [1, 2, 3]}
+    ]`))
+
+	err(t, []byte(` [
+        {"Order": [{"Id": 1}, {"Id": 2}, {"Id": 3}]},
+        {"Order": [[]]}
+    ]`))
+
+	err(t, []byte(` [
+        {"Order": [{"Id": 1}, {"Id": 2}, {"Id": 3}]},
+        {"Order": [{}]}
+    ]`))
+}


### PR DESCRIPTION
This change allows to load both tab-delimited and JSON files. It is only supported to load JSON files where every array contains elements of the same type:
- objects must have the same attributes
- string, numbers and booleans are considered equal

Valid inputs:

```
[ 1, 2, "hello world" ]
[ {"id": 1}, {"id": 2} ]
[ [1,2], [] ]
[ {"elems": []}, {"elems": [{}]} ]
```

Invalid inputs:

```
[ 1, {} ]
[ [], {} ]
[ {"id": 1}, {"name": ""} ]
[ {"elems": [1]}, {"elems": [{}]} ]
```

Example with a single object on the top level:

```
$ cat tennis.json 
{"name":"tennis",
 "type":"FeatureCollection",
 "features":[
   {"type":"Feature",
    "geometry":{"type":"Point","coordinates":[8.57099155101007,47.350064305313]},
    "properties":{
      "City": "Zürich",
      "Address":"Bleulerstrasse 41",
      "Tel":"044 381 13 13",
      "Name":"Tennis Lengg"}}]
}
```

and the query:

```
[ a.properties | a <- tennis.features, a.geometry.type == "Point" ]
```
