### PR TITLE
accessing list elements by constant index

### DIFF
--- a/src/comp/expr.go
+++ b/src/comp/expr.go
@@ -81,6 +81,12 @@ func (e Expr) Field(name string, pos *int) Expr {
 	}}
 }
 
+func (e Expr) Index(name string, pos *int) Expr {
+	return Expr{nextEID(), fmt.Sprintf("%v[%v]", e.Name, name), func() []Op {
+		return append(e.Code(), OpIndex(*pos))
+	}}
+}
+
 func (l Expr) Binary(r Expr, op Op, name string) Expr {
 	return Expr{nextEID(), fmt.Sprintf("%v %v %v", l.Name, name, r.Name), func() []Op {
 		lc := l.Code()

--- a/src/comp/grammar.y
+++ b/src/comp/grammar.y
@@ -231,6 +231,12 @@ postfix_expression:
 		$$ = $1.Field($3, pos)
 		gDecls.SetType($$, TypeOfField{$1.Id, $3})
 	}
+    | postfix_expression '[' NUMBER ']'
+	{
+		pos := int($3)
+		$$ = $1.Index(fmt.Sprintf("%f",$3), &pos)
+		gDecls.SetType($$, TypeOfElem($1.Id))
+	}
     | postfix_expression '(' expression_list_or_empty ')'
 	{
 		eids := make([]int64, len($3))

--- a/src/comp/machine.go
+++ b/src/comp/machine.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 Ostap Cherkashin. You can use this source code
+// Copyright (c) 2013 Ostap Cherkashin, Julius Chrobak. You can use this source code
 // under the terms of the MIT License found in the LICENSE file.
 
 package main
@@ -35,6 +35,7 @@ const (
 	opObject // allocate a new object on the stack with that many fields
 	opSet    // set a field of an object to a value from the stack
 	opGet    // get a field of an object and push it on the stack
+	opIndex  // get an element of a list and push it on the stack
 	opLoop   // prepare for iteration over a list from the stack
 	opNext   // push the next element from the list on the stack and jump to op.Arg
 	opTest   // jump to op.Arg if the top of the stack is false
@@ -154,6 +155,13 @@ func (p *Program) Run(s *Stack) Value {
 			obj := s.PopObj()
 			val := obj[op.Arg]
 			s.Push(val)
+		case opIndex:
+			list := s.PopList()
+			if op.Arg > -1 && op.Arg < len(list) {
+				s.Push(list[op.Arg])
+			} else {
+				s.Push(String(""))
+			}
 		case opArg:
 			s.Push(Number(op.Arg))
 		case opLoop:
@@ -324,6 +332,8 @@ func (op Op) String() string {
 		return fmt.Sprintf("set %d", op.Arg)
 	case opGet:
 		return fmt.Sprintf("get %d", op.Arg)
+	case opIndex:
+		return fmt.Sprintf("get %d", op.Arg)
 	case opLoop:
 		return fmt.Sprintf("loop %d", op.Arg)
 	case opNext:
@@ -431,6 +441,10 @@ func OpSet(field int) Op {
 
 func OpGet(field int) Op {
 	return Op{opGet, field}
+}
+
+func OpIndex(field int) Op {
+	return Op{opIndex, field}
 }
 
 func OpLoop(lid int) Op {

--- a/src/comp/web_test.go
+++ b/src/comp/web_test.go
@@ -291,11 +291,19 @@ func ExampleLists() {
 	run("[true, false]")
 	run("[1,2,3]")
 	run(`["a","b","c"]`)
+	run(`["a","b","c"][0]`)
+	run(`["a","b","c"][3]`)
+	run(`["a","b","c"][1.999]`)
+	run(`[{id:0},{id:1},{id:2}][1]`)
 
 	// Output:
 	// [true,false]
 	// [1,2,3]
 	// ["a","b","c"]
+	// "a"
+	// ""
+	// "b"
+	// {"id":1}
 }
 
 func ExampleObjects() {


### PR DESCRIPTION
allows to access list elements by a constant index. If the index is out of range it returns default value of an empty string. This not an ideal solution, but it is a bigger problem and could be resolved as part of the #7 issue which is suppose to support expressions to look up attributes.
