### PR TITLE
supporting multiple cores for the command line mode

### DIFF
--- a/src/comp/store.go
+++ b/src/comp/store.go
@@ -65,6 +65,13 @@ func BuildStore(files string) (Store, error) {
 		}
 	}
 
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	log.Printf("garbage collecting (heap ~%vMB)", m.Alloc/1024/1024)
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	log.Printf("done (heap ~%vMB)", m.Alloc/1024/1024)
+
 	return store, err
 }
 


### PR DESCRIPTION
Allowing to use multiple CPUs (cores) in the command line mode. This allows to run queries in parallel using the `<~` operator. 

In addition, it also executes the garbage collection in the command line mode after the initialization of the input files.
