### PR TITLE
fixing incorrect evaluation of the select conditions for inner loops

### DIFF
--- a/src/comp/loop.go
+++ b/src/comp/loop.go
@@ -92,7 +92,7 @@ func (l *Loop) Nest(lid int, varAddr int, list Expr, parallel bool) *Loop {
 
 func (l *Loop) Select(expr Expr) *Loop {
 	i := l.innermost()
-	i.sel = append(l.sel, expr)
+	i.sel = append(i.sel, expr)
 	return l
 }
 

--- a/src/comp/web_test.go
+++ b/src/comp/web_test.go
@@ -377,6 +377,8 @@ func ExampleComps() {
 	run("[i * j | i <- [1, 2, 3], trunc(i), j <- [10, 20]]")
 	run(`[ i["a"] | i <- [{a: "a"}, {"b"}, {"c"}]]`)
 	run(`[ i["\"a\""] | i <- [{"a"}, {"b"}, {"c"}]]`)
+	run(`[{g,c}|g <- [1], c <- [0], c-1 == 0 && c == 0]`)
+	run(`[{g,c}|g <- [1], c <- [0], c-1 == 0, c == 0]`)
 
 	// Output:
 	// [1,2,3]
@@ -391,6 +393,8 @@ func ExampleComps() {
 	// [10,20,20,40,30,60]
 	// ["a","b","c"]
 	// ["a","b","c"]
+	// null
+	// null
 }
 
 func ExampleFuncs() {


### PR DESCRIPTION
The select conditions for the inner loops are badly assigned and evaluated while executing the outer loop.

The following comprehension returns null:

```
$ bin/comp '[{g,c}|g <- [1], c <- [0], c-1 == 0 && c == 0]' 2> /dev/null
$
```

While the following returns unexpectedly some data:

```
$ bin/comp '[{g,c}|g <- [1], c <- [0], c-1 == 0, c == 0]' 2> /dev/null
[ { "g": 1, "c": 0 } ]
$
```
